### PR TITLE
style: Fix linebreak-style error on windows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@coolizz/eslint-config"],
   "rules": {
-    "react/jsx-boolean-value": "off"
+    "react/jsx-boolean-value": "off",
+    "linebreak-style": "off"
   }
 }


### PR DESCRIPTION
為了兼容不同作業系統，移除 eslint linebreak-style rule，交給 git 自動轉換。