### PR TITLE
feat: SignOut session & redirect on token expired

### DIFF
--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,13 +1,22 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from '@chakra-ui/next-js';
 import { Container, VStack, Button } from '@chakra-ui/react';
 import InputWithErrMsg from '@/components/common/InputWithErrMsg';
+import { useSearchParams } from 'next/navigation';
+import { signOut } from 'next-auth/react';
 import useSigninForm from './useSigninForm';
 
 const Signin = () => {
   const { onChangeHandler, form, errMsgMap, onSubmit } = useSigninForm();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get('signOut')) {
+      signOut({ redirect: false });
+    }
+  }, []);
 
   return (
     <Container w="50%" margin="auto" py="80px">

--- a/src/lib/api/HttpStatusError.ts
+++ b/src/lib/api/HttpStatusError.ts
@@ -1,0 +1,14 @@
+export class HttpStatusError extends Error {
+  status: number;
+
+  data: unknown;
+
+  constructor(status: number, message: string, data: unknown) {
+    super(message);
+
+    Object.setPrototypeOf(this, new.target.prototype);
+
+    this.status = status;
+    this.data = data;
+  }
+}


### PR DESCRIPTION
1. auth token 過期時自動登出，並 redirect 到登入頁面
2. fetch 收到 4xx、5xx 的 response 時不會拋出 error，只會把 response.ok 設為 false。為了符合現在的串接方式，當 response.ok 為 false，httpClient 會拋出 HttpStatusError。